### PR TITLE
Set grainColumnName as optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domoinc/domo-phoenix",
-  "version": "0.20.1",
+  "version": "0.20.2",
   "description": "Build beautiful charts using Domo's powerful charting engine",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/interfaces/phoenix-chart-data.ts
+++ b/src/interfaces/phoenix-chart-data.ts
@@ -11,7 +11,7 @@ export const CalendarJoinColumns = {
 };
 
 export interface PhoenixChartDataColumn extends ChartDataColumnBase {
-  grainColumnName: keyof typeof CalendarJoinColumns;
+  grainColumnName?: keyof typeof CalendarJoinColumns;
 }
 
 interface ChartDataColumnBase {


### PR DESCRIPTION
Setting the `grainColumnName` as optional in the `PhoenixChartDataColumn` interface as it was causing errors when initializing ChartData objects.

The documentation has multiple spots where objects using this interface's structure are shown but the `grainColumnName` field was missing. A customer run into errors while creating charts, following the steps in the docs.

e.g. https://domoapps.github.io/domo-phoenix/#/domo-phoenix/framework/react where `type`, `name`, and `mapping` are correctly listed, but not `grainColumnName`.

Since `grainColumnName` seems to be linked to `dateGrain`, we're thinking it can be marked as optional instead.

If it is actually meant to be required, we'll need to update the docs.

-- Bug reported by @WaldoMarais